### PR TITLE
UIをシンプルに改善

### DIFF
--- a/raw_content.js
+++ b/raw_content.js
@@ -8,32 +8,27 @@
 
   console.log('GitHub Raw HTML Viewer: ボタンを作成します');
   const btn = document.createElement('button');
-  btn.textContent = 'HTMLプレビュー';
+  btn.textContent = 'Preview';
   Object.assign(btn.style, {
     position: 'fixed',
     top: '10px',
     right: '10px',
     zIndex: 99999,
-    padding: '8px 16px',
-    background: '#2da44e',
+    padding: '6px 12px',
+    background: '#0969da',
     color: '#ffffff',
     border: 'none',
-    borderRadius: '6px',
+    borderRadius: '4px',
     fontSize: '14px',
-    fontWeight: '500',
-    cursor: 'pointer',
-    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)',
-    transition: 'all 0.3s cubic-bezier(.25,.8,.25,1)'
+    cursor: 'pointer'
   });
 
   btn.addEventListener('mouseenter', () => {
-    btn.style.background = '#2c974b';
-    btn.style.boxShadow = '0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23)';
+    btn.style.background = '#0860ca';
   });
 
   btn.addEventListener('mouseleave', () => {
-    btn.style.background = '#2da44e';
-    btn.style.boxShadow = '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24)';
+    btn.style.background = '#0969da';
   });
 
   document.documentElement.appendChild(btn);


### PR DESCRIPTION
## Summary
- プレビューボタンのUIをよりシンプルでモダンなデザインに改善しました
- 不要なスタイリングを削除し、最小限のスタイルで実装

## Changes
- ボタンテキストを「HTMLプレビュー」から「Preview」に変更
- ボタンのスタイルをシンプル化：
  - パディングを控えめに調整 (8px 16px → 6px 12px)
  - 背景色をGitHubライクな青色に変更 (#2da44e → #0969da)
  - 角丸を小さく調整 (6px → 4px)
  - 影やトランジションエフェクトを削除してシンプルに
  - フォントウェイトの指定を削除

## Test plan
- [ ] Chrome拡張機能をリロード
- [ ] raw.githubusercontent.comでHTMLファイルを開く
- [ ] 右上にシンプルな青い「Preview」ボタンが表示されることを確認
- [ ] ボタンのホバー時に色が変わることを確認
- [ ] ボタンクリックでHTMLプレビューが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF < /dev/null
