### PR TITLE
fix: サンドボックスエラーの解決

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,18 +20,12 @@ ${html}
 </body>
 </html>`;
     
-    // Blob URLを作成（ダウンロードではなくブラウザで表示）
-    const blob = new Blob([fullHtml], { type: 'text/html;charset=utf-8' });
-    const blobUrl = URL.createObjectURL(blob);
+    // Data URLを使用してHTMLを直接開く（スクリプト実行を許可）
+    const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(fullHtml)}`;
     
     // 新しいタブで開く
-    chrome.tabs.create({ url: blobUrl }, (tab) => {
+    chrome.tabs.create({ url: dataUrl }, (tab) => {
       console.log('Background: 新しいタブを作成しました', tab.id);
-      
-      // 30秒後にBlob URLを解放
-      setTimeout(() => {
-        URL.revokeObjectURL(blobUrl);
-      }, 30000);
     });
     
     sendResponse({ success: true });


### PR DESCRIPTION
## 概要
GitHub Raw HTMLプレビュー機能で発生していたサンドボックスエラーを解決しました。

## 問題
`https://raw.githubusercontent.com/***/***-guide.html` のようなURLでHTMLをプレビューする際に、以下のエラーが発生していました：

```
Blocked script execution in 'https://raw.githubusercontent.com/.../***-guide.html'
because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
```

## 原因
Blob URLを使用してHTMLコンテンツを新しいタブで開く際、ブラウザが自動的にサンドボックス制限を適用し、JavaScriptの実行がブロックされていました。

## 解決策
Blob URLの代わりにData URLを使用することで、この問題を解決しました。Data URLはブラウザによって通常のHTMLドキュメントとして扱われ、JavaScriptの実行が許可されます。

## 変更内容
- `background.js`: Blob URLからData URLへの変更
  - メモリリークの心配がなくなったため、URLの解放処理も削除

## テスト
- [x] HTMLプレビューが正常に開く
- [x] プレビュー内のJavaScriptが実行される
- [x] エラーメッセージが表示されない

🤖 Generated with [Claude Code](https://claude.ai/code)