### PR TITLE
fix: サンドボックスエラーの根本的解決

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,11 +20,13 @@ ${html}
 </body>
 </html>`;
     
-    // Data URLを使用してHTMLを直接開く（スクリプト実行を許可）
-    const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(fullHtml)}`;
+    // 拡張機能のプレビューページを使用してHTMLを表示
+    const previewUrl = chrome.runtime.getURL('preview.html') + 
+      '?html=' + encodeURIComponent(html) + 
+      '&baseUrl=' + encodeURIComponent(baseUrl);
     
     // 新しいタブで開く
-    chrome.tabs.create({ url: dataUrl }, (tab) => {
+    chrome.tabs.create({ url: previewUrl }, (tab) => {
       console.log('Background: 新しいタブを作成しました', tab.id);
     });
     

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,12 @@
   "version": "1.0.0",
   "description": "View raw HTML files from GitHub as rendered HTML pages",
   "permissions": ["scripting", "activeTab", "tabs"],
+  "web_accessible_resources": [
+    {
+      "resources": ["preview.html", "preview.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "host_permissions": ["https://raw.githubusercontent.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>HTML Preview</title>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+        #preview-frame {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+    </style>
+</head>
+<body>
+    <iframe id="preview-frame" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"></iframe>
+    <script src="preview.js"></script>
+</body>
+</html>

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,26 @@
+// URLパラメータからHTMLコンテンツを取得
+const params = new URLSearchParams(window.location.search);
+const htmlContent = params.get('html');
+const baseUrl = params.get('baseUrl');
+
+if (htmlContent && baseUrl) {
+    // デコードしたHTMLコンテンツを構築
+    const decodedHtml = decodeURIComponent(htmlContent);
+    
+    // 完全なHTMLドキュメントを作成
+    const fullHtml = `<!DOCTYPE html>
+<html>
+<head>
+    <base href="${baseUrl}">
+    <meta charset="UTF-8">
+    <title>HTML Preview</title>
+</head>
+<body>
+${decodedHtml}
+</body>
+</html>`;
+    
+    // iframeにHTMLを設定
+    const iframe = document.getElementById('preview-frame');
+    iframe.srcdoc = fullHtml;
+}


### PR DESCRIPTION
## 概要
GitHub Raw HTMLプレビュー機能で発生していたサンドボックスエラーを根本的に解決しました。

## 問題
`https://raw.githubusercontent.com/***/***-guide.html` のようなURLでHTMLをプレビューする際に、以下のエラーが発生していました：

```
Blocked script execution in 'https://raw.githubusercontent.com/***/***/***-guide.html'
because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
```

## 原因
Data URLやBlob URLを使用してHTMLコンテンツを新しいタブで開く際、ブラウザが自動的にサンドボックス制限を適用し、JavaScriptの実行がブロックされていました。

## 解決策
拡張機能内に専用のプレビューページ（`preview.html`）を作成し、そこでiframeを使用してコンテンツを表示する方法に変更しました。これにより、sandbox属性を明示的に制御でき、必要な権限を適切に設定できます。

## 技術的詳細
1. **preview.html**: iframeを含む専用のプレビューページ
   - sandbox属性に`allow-scripts`を含む必要な権限を明示的に設定
2. **preview.js**: URLパラメータからHTMLコンテンツを取得し、iframeのsrcdocに設定
3. **background.js**: `chrome.runtime.getURL()`を使用して拡張機能内のpreview.htmlを開く
4. **manifest.json**: `web_accessible_resources`を追加して、preview.htmlとpreview.jsをアクセス可能に

## テスト
- [x] HTMLプレビューが正常に開く
- [x] プレビュー内のJavaScriptが実行される
- [x] サンドボックスエラーが表示されない
- [x] 相対パスのリソース（CSS、画像など）が正しく読み込まれる

## セキュリティ考慮事項
- iframeにはsandbox属性を設定し、最小限必要な権限のみを付与
- `allow-scripts`: JavaScriptの実行を許可
- `allow-same-origin`: 同一オリジンポリシーを維持（相対パスのリソース読み込みに必要）
- `allow-forms`, `allow-popups`, `allow-modals`, `allow-downloads`: 一般的なWebページ機能をサポート

🤖 Generated with [Claude Code](https://claude.ai/code)