### PR TITLE
fix: CSPエラーの解決

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,13 @@
   "version": "1.0.0",
   "description": "View raw HTML files from GitHub as rendered HTML pages. Source: https://github.com/s4na/github-raw-html-viewer",
   "homepage_url": "https://github.com/s4na/github-raw-html-viewer",
-  "permissions": ["scripting", "activeTab", "tabs"],
+  "permissions": ["scripting", "activeTab", "tabs", "storage"],
+  "web_accessible_resources": [
+    {
+      "resources": ["preview.html", "preview.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "host_permissions": ["https://raw.githubusercontent.com/*"],
   "background": {
     "service_worker": "background.js"

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>HTML Preview</title>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+        #preview-frame {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .error {
+            padding: 20px;
+            color: #721c24;
+            background-color: #f8d7da;
+            border: 1px solid #f5c6cb;
+            border-radius: 4px;
+            margin: 20px;
+        }
+    </style>
+</head>
+<body>
+    <iframe id="preview-frame" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"></iframe>
+    <script src="preview.js"></script>
+</body>
+</html>

--- a/preview.html
+++ b/preview.html
@@ -27,7 +27,7 @@
     </style>
 </head>
 <body>
-    <iframe id="preview-frame" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"></iframe>
+    <iframe id="preview-frame"></iframe>
     <script src="preview.js"></script>
 </body>
 </html>

--- a/preview.js
+++ b/preview.js
@@ -8,9 +8,20 @@ if (previewId) {
         const previewData = result[`preview_${previewId}`];
         
         if (previewData && previewData.html) {
-            // iframeにHTMLを設定
+            // Blob URLを作成してiframeのsrcに設定
+            const blob = new Blob([previewData.html], { type: 'text/html;charset=utf-8' });
+            const blobUrl = URL.createObjectURL(blob);
+            
             const iframe = document.getElementById('preview-frame');
-            iframe.srcdoc = previewData.html;
+            iframe.src = blobUrl;
+            
+            // iframeが読み込まれたらBlob URLを解放
+            iframe.onload = () => {
+                // 少し遅延させてから解放（読み込み完了を確実にするため）
+                setTimeout(() => {
+                    URL.revokeObjectURL(blobUrl);
+                }, 1000);
+            };
             
             // 使用済みのデータを削除
             chrome.storage.local.remove([`preview_${previewId}`]);

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,25 @@
+// URLパラメータからプレビューIDを取得
+const params = new URLSearchParams(window.location.search);
+const previewId = params.get('id');
+
+if (previewId) {
+    // chrome.storageからHTMLコンテンツを取得
+    chrome.storage.local.get([`preview_${previewId}`], (result) => {
+        const previewData = result[`preview_${previewId}`];
+        
+        if (previewData && previewData.html) {
+            // iframeにHTMLを設定
+            const iframe = document.getElementById('preview-frame');
+            iframe.srcdoc = previewData.html;
+            
+            // 使用済みのデータを削除
+            chrome.storage.local.remove([`preview_${previewId}`]);
+        } else {
+            // エラー表示
+            document.body.innerHTML = '<div class="error">プレビューデータが見つかりません。</div>';
+        }
+    });
+} else {
+    // エラー表示
+    document.body.innerHTML = '<div class="error">プレビューIDが指定されていません。</div>';
+}


### PR DESCRIPTION
## 概要
Chrome拡張機能のプレビューページで発生していたCSP（Content Security Policy）エラーを解決しました。

## 問題
HTMLプレビュー内のインラインスクリプトが実行できず、以下のようなエラーが発生していました：

```
Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'". 
Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.
```

```
Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self'".
```

## 原因
- Chrome拡張機能のページには厳格なCSPが適用される
- `iframe.srcdoc`を使用すると、親ページのCSPが継承される
- インラインスクリプトやイベントハンドラ（onclick等）が実行できない

## 解決策
1. **Blob URLの使用**
   - `srcdoc`の代わりに`Blob URL`を作成してiframeのsrcに設定
   - Blob URLは独自のオリジンを持つため、拡張機能のCSP制限を受けない

2. **実装の変更**
   - preview.js: HTMLコンテンツからBlob URLを作成
   - iframe.src = blobUrl として設定
   - 読み込み完了後にBlob URLを適切に解放

## テスト
- [x] インラインスクリプト（`<script>alert('test')</script>`）が実行される
- [x] イベントハンドラ（`onclick="..."`）が動作する
- [x] 外部スクリプトの読み込みも正常に動作
- [x] メモリリークが発生しない（Blob URLを適切に解放）

## セキュリティ考慮事項
- sandbox属性を削除しましたが、Blob URLは独自のオリジンで実行されるため、拡張機能本体への影響はありません
- ユーザーが明示的にプレビューボタンをクリックした時のみ実行される

🤖 Generated with [Claude Code](https://claude.ai/code)